### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add a step to your workflow like below:
   steps:
   - uses: KengoTODA/actions-setup-docker-compose@main
     with:
-      version: '1.26.2'
+      version: '1.29.2'
 ```
 
 The `version` parameter is required, specify the full version of `docker-compose` command.


### PR DESCRIPTION
README is used by users as a source of copy&paste so it would be better it is more up to date with the latest version of docker-compose.

`version` has been updated to the latest 1.x: [1.29.2](https://github.com/docker/compose/releases/tag/1.29.2)

I intentionally omitted 2.x for now since it is just 2 weeks old.