### PR TITLE
docker-compose v2 has lower-case platform name

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -17,12 +17,13 @@ export async function runCommand(command: string): Promise<string> {
 }
 
 async function installOnLinux(version: string): Promise<string> {
-  const system = runCommand('uname -s')
-  const hardware = runCommand('uname -m')
+  let system = await runCommand('uname -s')
+  const hardware = await runCommand('uname -m')
   if (!version.startsWith('v') && parseInt(version.split('.')[0], 10) >= 2) {
     version = `v${version}`
+    system = system.toLowerCase()
   }
-  const url = `https://github.com/docker/compose/releases/download/${version}/docker-compose-${await system}-${await hardware}`
+  const url = `https://github.com/docker/compose/releases/download/${version}/docker-compose-${system}-${hardware}`
   const installerPath = await downloadTool(url)
   await exec(`chmod +x ${installerPath}`)
   const cachedPath = await cacheFile(


### PR DESCRIPTION
The 2.x binaries has lowercase "darwin" and "linux": https://github.com/docker/compose/releases/tag/v2.10.2
While the 1.x binaries are uppercased: https://github.com/docker/compose/releases/tag/1.29.2